### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/fastcampus/sparta09projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/sparta09projectboard/repository/ArticleRepository.java
@@ -2,5 +2,7 @@ package com.fastcampus.sparta09projectboard.repository;
 
 import com.fastcampus.sparta09projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource// spring data rest 설정 추가
 public interface ArticleRepository extends JpaRepository<Article, Long> {}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,3 +27,6 @@ spring:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated

--- a/src/test/java/com/fastcampus/sparta09projectboard/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/sparta09projectboard/controller/DataRestTest.java
@@ -1,0 +1,57 @@
+package com.fastcampus.sparta09projectboard.controller;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// 상대적으로 무거운 테스트
+@DisplayName("Data Rest - 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+  private final MockMvc mvc;
+
+  public DataRestTest(@Autowired MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  @DisplayName("[api] 게시글 리스트 조회")
+  @Test
+  void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+    // Given
+
+    // When : 잘 던져지는지만 테스트하기
+    mvc.perform(get("/api/articles"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+        .andDo(print());
+
+    // Then
+  }
+
+  @DisplayName("[api] 게시글 단건 조회")
+  @Test
+  void givenNothing_whenRequestingArticles_thenReturnsArticleJsonResponse() throws Exception {
+    // Given
+
+    // When : 잘 던져지는지만 테스트하기
+    mvc.perform(get("/api/articles/1"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+            .andDo(print());
+
+    // Then
+  }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 api들의 존재여부만 체크하게끔 통합테스트 작성